### PR TITLE
Remove all trailing slashes and don't add any

### DIFF
--- a/alti+server
+++ b/alti+server
@@ -813,7 +813,7 @@ has occured.  After too many infractions, the player is kicked by the server.
 	our($Goals)=6;  #reset from launcher_config.xml
 	our($Maxp)=14;  #reset from launcher_config.xml
 
-	$MAPDIR=~s|/*$|/| if($MAPDIR);
+	$MAPDIR=~s|/*$|| if($MAPDIR);
 
 	sub option_exists {
 		return(exists($OPTIONS{$_[0]}));


### PR DESCRIPTION
Map names are being displayed as 'mapdir//name' this is because
the regex is always adding a / but then when we construct the path
to the map we use '..$MAPDIR/..' so we're already adding the slash
so the regex should be changed to remove all trailing slashes entirely.
